### PR TITLE
docker: clean up the Dockerfile and speed up the build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,6 @@ FROM fedora:30
 LABEL maintainer="andy.rudoff@intel.com"
 
 RUN dnf update -y && dnf install -y\
-	asciidoc\
-	asciidoctor\
 	autoconf\
 	automake\
 	bash-completion\
@@ -35,18 +33,11 @@ RUN dnf update -y && dnf install -y\
 	git-all\
 	glib2-devel\
 	golang\
-	gtest-devel\
-	hub\
-	json-c-devel\
-	keyutils-libs-devel\
-	kmod-devel\
 	lbzip2\
 	libatomic\
 	libtool\
 	libudev-devel\
 	libunwind-devel\
-	libuuid-devel\
-	libuv-devel\
 	make\
 	man\
 	memkind\
@@ -75,16 +66,11 @@ RUN dnf update -y && dnf install -y\
 	vim-enhanced\
 	wget\
 	which\
-	xmlto\
-	xmvn
-
-RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash -
-
-RUN dnf install -y nodejs
-
-RUN dnf debuginfo-install -y glibc
-
-RUN dnf clean all
+	xmvn\
+ && curl -sL https://rpm.nodesource.com/setup_10.x | bash - \
+ && dnf install -y nodejs \
+ && dnf debuginfo-install -y glibc \
+ && dnf clean all
 
 COPY pmdk.sh /
 RUN /pmdk.sh
@@ -97,9 +83,6 @@ RUN /pmemobj-cpp.sh
 
 COPY pmemkv.sh /
 RUN /pmemkv.sh
-
-COPY pmemkv-jni.sh /
-RUN /pmemkv-jni.sh
 
 COPY pmemkv-java.sh /
 RUN /pmemkv-java.sh
@@ -119,4 +102,4 @@ RUN /memkind.sh
 COPY tz.sh /
 RUN /tz.sh
 
-RUN rm /pmdk.sh /valgrind.sh /pmemobj-cpp.sh /pmemkv.sh /pmemkv-jni.sh /pmemkv-java.sh /pmemkv-python.sh /pmemkv-nodejs.sh /pmemkv-ruby.sh /memkind.sh /tz.sh
+RUN rm /pmdk.sh /valgrind.sh /pmemobj-cpp.sh /pmemkv.sh /pmemkv-java.sh /pmemkv-python.sh /pmemkv-nodejs.sh /pmemkv-ruby.sh /memkind.sh /tz.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,6 +84,10 @@ RUN /pmemobj-cpp.sh
 COPY pmemkv.sh /
 RUN /pmemkv.sh
 
+# Prepare extra maven params
+# It's executed and its result is exported within 'pmemkv-java.sh'
+COPY setup-maven-settings.sh /setup-maven-settings.sh
+
 COPY pmemkv-java.sh /
 RUN /pmemkv-java.sh
 
@@ -102,4 +106,4 @@ RUN /memkind.sh
 COPY tz.sh /
 RUN /tz.sh
 
-RUN rm /pmdk.sh /valgrind.sh /pmemobj-cpp.sh /pmemkv.sh /pmemkv-java.sh /pmemkv-python.sh /pmemkv-nodejs.sh /pmemkv-ruby.sh /memkind.sh /tz.sh
+RUN rm /pmdk.sh /valgrind.sh /pmemobj-cpp.sh /pmemkv.sh /setup-maven-settings.sh /pmemkv-java.sh /pmemkv-python.sh /pmemkv-nodejs.sh /pmemkv-ruby.sh /memkind.sh /tz.sh

--- a/docker/memkind.sh
+++ b/docker/memkind.sh
@@ -1,9 +1,12 @@
 #!/bin/bash -ex
 
 git clone https://github.com/memkind/memkind
-cd memkind
-git checkout v1.9.0
-./build.sh --prefix=/usr
-sudo make install
-cd ..
+pushd memkind
+
+./autogen.sh
+./configure --prefix=/usr
+make -j$(nproc)
+make -j$(nproc) install
+
+popd
 rm -r memkind

--- a/docker/pmdk.sh
+++ b/docker/pmdk.sh
@@ -1,8 +1,10 @@
 #!/bin/bash -ex
 
 git clone https://github.com/pmem/pmdk
-cd pmdk
-make
-make install prefix=/usr
-cd ..
+pushd pmdk
+
+make -j$(nproc)
+make -j$(nproc) install prefix=/usr
+
+popd
 rm -r pmdk

--- a/docker/pmemkv-java.sh
+++ b/docker/pmemkv-java.sh
@@ -1,9 +1,15 @@
 #!/bin/bash -ex
 
+# Include setup of extra maven parameters (proxies)
+source /setup-maven-settings.sh
+
+MVN_PARAMS="${PMEMKV_MVN_PARAMS}"
+echo "Extra mvn params (taken from env variable): ${MVN_PARAMS}"
+
 git clone https://github.com/pmem/pmemkv-java.git
 pushd pmemkv-java
 
-mvn install -Dmaven.test.skip=true
+mvn install -Dmaven.test.skip=true ${MVN_PARAMS}
 
 popd
 rm -r pmemkv-java

--- a/docker/pmemkv-java.sh
+++ b/docker/pmemkv-java.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -ex
 
 git clone https://github.com/pmem/pmemkv-java.git
-cd pmemkv-java
-export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
-mvn install
-cd ..
+pushd pmemkv-java
+
+mvn install -Dmaven.test.skip=true
+
+popd
 rm -r pmemkv-java

--- a/docker/pmemkv-jni.sh
+++ b/docker/pmemkv-jni.sh
@@ -1,8 +1,0 @@
-#!/bin/bash -ex
-
-git clone https://github.com/pmem/pmemkv-jni.git
-cd pmemkv-jni
-make
-make install prefix=/usr
-cd ..
-rm -r pmemkv-jni

--- a/docker/pmemkv-nodejs.sh
+++ b/docker/pmemkv-nodejs.sh
@@ -1,7 +1,9 @@
 #!/bin/bash -ex
 
 git clone https://github.com/pmem/pmemkv-nodejs.git
-cd pmemkv-nodejs
+pushd pmemkv-nodejs
+
 npm install
-cd ..
+
+popd
 rm -r pmemkv-nodejs

--- a/docker/pmemkv-python.sh
+++ b/docker/pmemkv-python.sh
@@ -1,7 +1,9 @@
 #!/bin/bash -ex
 
 git clone https://github.com/pmem/pmemkv-python.git
-cd pmemkv-python
+pushd pmemkv-python
+
 python3 setup.py install
-cd ..
+
+popd
 rm -r pmemkv-python

--- a/docker/pmemkv-ruby.sh
+++ b/docker/pmemkv-ruby.sh
@@ -1,14 +1,13 @@
 #!/bin/bash -ex
 
-# all of the dependencies (gems) needed to run pmemkv-ruby will be saved in
-# /opt/bindings/ruby directory
-mkdir -p /opt/bindings/ruby/
-sudo gem install bundler -v '< 2.0'
+gem install bundler -v '< 2.0'
 git clone https://github.com/pmem/pmemkv-ruby.git
-cd pmemkv-ruby
+pushd pmemkv-ruby
+
 # bundle package command copies all of the .gem files needed to run the application
 # into the vendor/cache directory
-sudo bundle package
-mv -v vendor/cache/* /opt/bindings/ruby/
-cd ..
+bundle package
+bundle install
+
+popd
 rm -rf pmemkv-ruby

--- a/docker/pmemkv.sh
+++ b/docker/pmemkv.sh
@@ -1,11 +1,11 @@
 #!/bin/bash -ex
 
 git clone https://github.com/pmem/pmemkv
-cd pmemkv
-mkdir build
-cd build
+mkdir -p pmemkv/build
+pushd pmemkv/build
+
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr
-make
-make install
-cd ../..
+make -j$(nproc) install
+
+popd
 rm -r pmemkv

--- a/docker/pmemobj-cpp.sh
+++ b/docker/pmemobj-cpp.sh
@@ -1,11 +1,11 @@
 #!/bin/bash -ex
 
 git clone https://github.com/pmem/libpmemobj-cpp
-cd libpmemobj-cpp
-mkdir build
-cd build
+mkdir -p libpmemobj-cpp/build
+pushd libpmemobj-cpp/build
+
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr
-make
-make install
-cd ../..
+make -j$(nproc) install
+
+popd
 rm -r libpmemobj-cpp

--- a/docker/setup-maven-settings.sh
+++ b/docker/setup-maven-settings.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2021, Intel Corporation
+
+#
+# setup-maven-settings.sh - setup some extra settings for maven
+#			It's executed in 'install-dependencies.sh', but it can also be
+#			run locally (or in a custom docker container) to setup
+#			these extra params for run-*.sh scripts.
+#
+
+# Split proxies into host & port; remove possible leftover "/"
+if [[ -n "${http_proxy}" ]]; then
+	http_proxy_ip=$(echo ${http_proxy} | cut -d: -f2 | sed 's/\///g')
+	http_proxy_port=$(echo ${http_proxy} | cut -d: -f3 | sed 's/\///g')
+fi
+if [[ -n "${https_proxy}" ]]; then
+	https_proxy_ip=$(echo ${https_proxy} | cut -d: -f2 | sed 's/\///g')
+	https_proxy_port=$(echo ${https_proxy} | cut -d: -f3 | sed 's/\///g')
+fi
+
+mvn_params=''
+[ -n "${http_proxy_ip}" ] && mvn_params="${mvn_params} -Dhttp.proxyHost=${http_proxy_ip}"
+[ -n "${http_proxy_port}" ] && mvn_params="${mvn_params} -Dhttp.proxyPort=${http_proxy_port}"
+[ -n "${https_proxy_ip}" ] && mvn_params="${mvn_params} -Dhttps.proxyHost=${https_proxy_ip}"
+[ -n "${https_proxy_port}" ] && mvn_params="${mvn_params} -Dhttps.proxyPort=${https_proxy_port}"
+
+# Export for current user/current shell
+export PMEMKV_MVN_PARAMS="${mvn_params}"

--- a/docker/tz.sh
+++ b/docker/tz.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 
 #fc30 timedatectl bug workaround:
-cd /etc
+pushd /etc
 rm localtime
 ln -s ../usr/share/zoneinfo/PST8PDT localtime
+popd

--- a/docker/valgrind.sh
+++ b/docker/valgrind.sh
@@ -1,12 +1,12 @@
 #!/bin/bash -ex
 
 git clone https://github.com/pmem/valgrind.git
-cd valgrind
-# valgrind v3.14 with pmemcheck: fix memcheck failure on Ubuntu-19.04
-#git checkout 0965e35d7fd5c7941dc3f2a0c981cb8386c479d3
+pushd valgrind
+
 ./autogen.sh
 ./configure --prefix=/usr
-make
-sudo make install
-cd ..
+make -j$(nproc)
+make -j$(nproc) install
+
+popd
 rm -r valgrind


### PR DESCRIPTION
- remove hardcoded memkind version in installation script - it should always use the most recent version (from master/main branch),
- make use of all cores while compiling all libs,
- remove redundant packages (mostly required for ndctl (?) ),
- remove redundant steps and comments,
- including removal of JNI, which is now built-in within Java binding.

// It's a continuation of my old work: https://github.com/pmemhackathon/2021-04-21.web/pull/2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmemhackathon/hackathon.web/7)
<!-- Reviewable:end -->
